### PR TITLE
Debug favicon transparency issue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         <meta property="og:title" content="avaneesh" />
         <meta property="og:description" content="@uvniche" />
         <meta property="og:image" content="https://www.uvniche.com/pfp.jpeg" />
-        <link rel="icon" href="/pfp-circle.png" type="image/png" />
+        <link rel="icon" href="/favicon.ico" type="image/x-icon" />
         <link rel="apple-touch-icon" href="/window.svg" />
       </head>
       <body


### PR DESCRIPTION
Update favicon link to point to the new `favicon.ico`.

The previous `favicon.ico` had a solid background and was taking precedence over the `pfp-circle.png` favicon. The user replaced the `favicon.ico` with a transparent version, and this change updates the link to reflect that.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a75bd3c-5225-4703-a60c-b1ee183aa0a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a75bd3c-5225-4703-a60c-b1ee183aa0a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

